### PR TITLE
Surefire Plugin error fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,14 @@
                     <artifactId>maven-antrun-plugin</artifactId>
                     <version>1.7</version>
                 </plugin>
+		<plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                    <configuration>
+                      <useSystemClassLoader>false</useSystemClassLoader>
+                    </configuration>
+               </plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
The surefire plugin behaves erratically with some versions of OpenJDK8.131 +. This is a workaround - see commit message for more details.