### PR TITLE
Use version annotated names for LLVM executables

### DIFF
--- a/bin/rvm-clang
+++ b/bin/rvm-clang
@@ -10,4 +10,4 @@ SRC_ROOT=`dirname "$SRC_ROOT"`
 # Move up into the actual source root directory
 SRC_ROOT="$SRC_ROOT/../"
 
-clang -Xclang -load -Xclang $SRC_ROOT/llvmaop/target/lib/LLVMAOP.so "$@"
+clang-6.0 -Xclang -load -Xclang $SRC_ROOT/llvmaop/target/lib/LLVMAOP.so "$@"

--- a/llvmaop/tests/after_call/Makefile
+++ b/llvmaop/tests/after_call/Makefile
@@ -2,21 +2,21 @@ all: test
 
 .PHONY: check
 
-#CC=clang -Xclang -load -Xclang ../../build/lib/LLVMAOP.so
-CC=rvmcc
+#CC=clang-6.0 -Xclang -load -Xclang ../../build/lib/LLVMAOP.so
+CC=rvm-clang
 CFLAGS=-flto=thin -O3
 
 aspect.o:
-	clang $(CFLAGS) -c aspect.c
+	clang-6.0 $(CFLAGS) -c aspect.c
 
 test_instr.o: aspect.map
 	$(CC) $(CFLAGS) -c test.c -o test_instr.o
 
 test_instr.o.ll: test_instr.o
-	llvm-dis test_instr.o
+	llvm-dis-6.0 test_instr.o
 
 test: aspect.o test_instr.o
-	clang -flto aspect.o test_instr.o -o test
+	clang-6.0 -flto aspect.o test_instr.o -o test
 
 check: test
 	./test || true

--- a/llvmaop/tests/before_call/Makefile
+++ b/llvmaop/tests/before_call/Makefile
@@ -2,23 +2,23 @@ all: test.bc
 
 .PHONY: check
 
-OPT=opt -load ../../build/lib/LLVMAOP.so
+OPT=opt-6.0 -load ../../build/lib/LLVMAOP.so
 CFLAGS=-flto=thin -O3
 
 aspect.bc: 
-	clang aspect.c -o aspect.bc -c -emit-llvm
+	clang-6.0 aspect.c -o aspect.bc -c -emit-llvm
 
 test0.bc: 
-	clang test.c -o test0.bc -c -emit-llvm
+	clang-6.0 test.c -o test0.bc -c -emit-llvm
 
 test_instr.bc: test0.bc aspect.map
 	$(OPT) -aop < test0.bc >test_instr.bc
 
 test.bc: aspect.bc test_instr.bc 
-	llvm-link  aspect.bc test_instr.bc -o test.bc
+	llvm-link-6.0  aspect.bc test_instr.bc -o test.bc
 
 check: test.bc
-	lli test.bc || true
+	lli-6.0 test.bc || true
 	
 clean:
 	rm -f *.bc 

--- a/llvmaop/tests/before_exec/Makefile
+++ b/llvmaop/tests/before_exec/Makefile
@@ -3,19 +3,19 @@ all: test
 .PHONY: check
 
 aspect.bc: 
-	clang -flto -fvisibility=hidden aspect.c -o aspect.bc -c -emit-llvm
+	clang-6.0 -flto -fvisibility=hidden aspect.c -o aspect.bc -c -emit-llvm
 
 test0.bc: 
-	clang -flto -fvisibility=hidden test.c -o test0.bc -c -emit-llvm
+	clang-6.0 -flto -fvisibility=hidden test.c -o test0.bc -c -emit-llvm
 
 test_instr.bc: test0.bc aspect.map
-	opt -load ../../build/lib/LLVMAOP.so -aop < test0.bc >test_instr.bc
+	opt-6.0 -load ../../build/lib/LLVMAOP.so -aop < test0.bc >test_instr.bc
 
 test.bc : aspect.bc test_instr.bc
-	llvm-link aspect.bc test_instr.bc | opt -internalize -internalize-public-api-list=main -Os -o test.bc
+	llvm-link-6.0 aspect.bc test_instr.bc | opt -internalize -internalize-public-api-list=main -Os -o test.bc
 
 test: aspect.bc test_instr.bc
-	clang -flto -Xlinker -emain aspect.bc test_instr.bc -o test
+	clang-6.0 -flto -Xlinker -emain aspect.bc test_instr.bc -o test
 
 check: test
 	./test || true

--- a/llvmaop/tests/instead-of_call/Makefile
+++ b/llvmaop/tests/instead-of_call/Makefile
@@ -3,19 +3,19 @@ all: test.bc
 .PHONY: check
 
 aspect.bc: 
-	clang aspect.c -o aspect.bc -c -emit-llvm
+	clang-6.0 aspect.c -o aspect.bc -c -emit-llvm
 
 test0.bc: 
-	clang test.c -o test0.bc -c -emit-llvm
+	clang-6.0 test.c -o test0.bc -c -emit-llvm
 
 test_instr.bc: test0.bc aspect.map
-	opt -load ../../build/lib/LLVMAOP.so -aop < test0.bc >test_instr.bc
+	opt-6.0 -load ../../build/lib/LLVMAOP.so -aop < test0.bc >test_instr.bc
 
 test.bc: aspect.bc test_instr.bc 
-	llvm-link  aspect.bc test_instr.bc -o test.bc
+	llvm-link-6.0  aspect.bc test_instr.bc -o test.bc
 	
 check: test.bc
-	lli test.bc || true
+	lli-6.0 test.bc || true
 
 clean:
 	rm -f *.bc 


### PR DESCRIPTION
 - LLVM distributed via (APT) Debian does not have non-annotated
 executable names.
 - Reduces risk of using wrong version in tests.