### PR TITLE
Switch From AntRun to Exec-Maven

### DIFF
--- a/bin/rvm-clang
+++ b/bin/rvm-clang
@@ -10,4 +10,4 @@ SRC_ROOT=`dirname "$SRC_ROOT"`
 # Move up into the actual source root directory
 SRC_ROOT="$SRC_ROOT/../"
 
-clang-6.0 -Xclang -load -Xclang $SRC_ROOT/llvmaop/target/lib/LLVMAOP.so "$@"
+clang-6.0 -Xclang -load -Xclang $SRC_ROOT/llvmaop/.build/lib/LLVMAOP.so "$@"

--- a/llvmaop/pom.xml
+++ b/llvmaop/pom.xml
@@ -9,25 +9,28 @@
     <name>llvmaop</name>
     <build>
         <plugins>
-          <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-antrun-plugin</artifactId>
-            <executions>
-              <execution>
-                <id>make</id>
-                <phase>compile</phase>
-                <goals><goal>run</goal></goals>
-                <configuration>
-                  <target>
-                    <exec executable="cmake" dir="${project.build.directory}" failonerror="true">
-                      <arg line="${project.basedir}"/>
-                    </exec>
-                    <exec executable="make" dir="${project.build.directory}" failonerror="true">
-                    </exec>
-                  </target>
-                </configuration>
-              </execution>
-            </executions>
+	  <plugin>
+             <groupId>org.codehaus.mojo</groupId>
+             <artifactId>exec-maven-plugin</artifactId>
+             <version>1.6.0</version>
+             <executions>
+               <execution>
+                 <id>make-llvmaop</id>
+                 <phase>compile</phase>
+                 <goals><goal>exec</goal></goals>
+                 <configuration>
+			 <executable> ${basedir}/scripts/build </executable>
+                 </configuration>
+               </execution>
+               <execution>
+                 <id>clean-llvmaop</id>
+                 <phase>clean</phase>
+                 <goals><goal>exec</goal></goals>
+                 <configuration>
+			 <executable> ${basedir}/scripts/clean </executable>
+                 </configuration>
+               </execution>
+             </executions>
           </plugin>
         </plugins>
     </build>

--- a/llvmaop/scripts/build
+++ b/llvmaop/scripts/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ue
+
+base=$(cd $(dirname $0)/..; pwd)
+build="$base/.build"
+
+mkdir -p "$build"
+( cd "$build" ; CC=clang-6.0 CXX=clang++-6.0 cmake "$base" ; make )

--- a/llvmaop/scripts/clean
+++ b/llvmaop/scripts/clean
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ue
+
+base=$(cd $(dirname $0)/..; pwd)
+build="$base/.build"
+
+rm -rf "$build"
+

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,11 @@
                       <useSystemClassLoader>false</useSystemClassLoader>
                     </configuration>
                </plugin>
+	       <plugin>
+                   <groupId>org.codehaus.mojo</groupId>
+                   <artifactId>exec-maven-plugin</artifactId>
+                   <version>1.6.0</version>
+        	</plugin>
             </plugins>
         </pluginManagement>
     </build>


### PR DESCRIPTION
@bmmoore small changes that allow building the llvm plugin via `mvn package` at the top level and cleaning via `mvn clean`. I'd suggest rebasing and merging as it's a very small change.