### PR TITLE
Support Parsing Generics in Advice Parameters Types

### DIFF
--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/ClassOrInterfaceType.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/ClassOrInterfaceType.java
@@ -1,0 +1,69 @@
+// Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
+/*
+ * Copyright (C) 2007 Julio Vilmar Gesser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Created on 05/10/2006
+ */
+package com.runtimeverification.rvmonitor.java.rvj.parser.ast.type;
+
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.GenericVisitor;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.VoidVisitor;
+
+import java.util.List;
+
+/**
+ * @author Julio Vilmar Gesser
+ */
+public final class ClassOrInterfaceType extends Type {
+
+    private final ClassOrInterfaceType scope;
+
+    private final String name;
+
+    private final List<Type> typeArgs;
+
+    public ClassOrInterfaceType(int line, int column, ClassOrInterfaceType scope, String name, List<Type> typeArgs) {
+        super(line, column);
+        this.scope = scope;
+        this.name = name;
+        this.typeArgs = typeArgs;
+    }
+
+    public ClassOrInterfaceType getScope() {
+        return scope;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<Type> getTypeArgs() {
+        return typeArgs;
+    }
+
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
+}

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/PrimitiveType.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/PrimitiveType.java
@@ -1,0 +1,58 @@
+// Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
+/*
+ * Copyright (C) 2007 Julio Vilmar Gesser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Created on 05/10/2006
+ */
+package com.runtimeverification.rvmonitor.java.rvj.parser.ast.type;
+
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.GenericVisitor;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.VoidVisitor;
+
+/**
+ * @author Julio Vilmar Gesser
+ */
+public final class PrimitiveType extends Type {
+
+    public enum Primitive {
+        Boolean, Char, Byte, Short, Int, Long, Float, Double
+    }
+
+    private final Primitive type;
+
+    public PrimitiveType(int line, int column, Primitive type) {
+        super(line, column);
+        this.type = type;
+    }
+
+    public Primitive getType() {
+        return type;
+    }
+
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
+
+}

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/ReferenceType.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/ReferenceType.java
@@ -1,0 +1,61 @@
+// Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
+/*
+ * Copyright (C) 2007 Julio Vilmar Gesser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Created on 05/10/2006
+ */
+package com.runtimeverification.rvmonitor.java.rvj.parser.ast.type;
+
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.GenericVisitor;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.VoidVisitor;
+
+/**
+ * @author Julio Vilmar Gesser
+ */
+public final class ReferenceType extends Type {
+
+    private final Type type;
+
+    private final int arrayCount;
+
+    public ReferenceType(int line, int column, Type type, int arrayCount) {
+        super(line, column);
+        this.type = type;
+        this.arrayCount = arrayCount;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    public int getArrayCount() {
+        return arrayCount;
+    }
+
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
+
+}

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/Type.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/Type.java
@@ -1,0 +1,36 @@
+// Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
+/*
+ * Copyright (C) 2007 Julio Vilmar Gesser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Created on 05/10/2006
+ */
+package com.runtimeverification.rvmonitor.java.rvj.parser.ast.type;
+
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.Node;
+
+/**
+ * @author Julio Vilmar Gesser
+ */
+public abstract class Type extends Node {
+
+    public Type(int line, int column) {
+        super(line, column);
+    }
+
+}

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/VoidType.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/VoidType.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
+/*
+ * Copyright (C) 2007 Julio Vilmar Gesser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Created on 05/10/2006
+ */
+package com.runtimeverification.rvmonitor.java.rvj.parser.ast.type;
+
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.GenericVisitor;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.VoidVisitor;
+
+/**
+ * @author Julio Vilmar Gesser
+ */
+public final class VoidType extends Type {
+
+    public VoidType(int line, int column) {
+        super(line, column);
+    }
+
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
+
+}

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/WildcardType.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/type/WildcardType.java
@@ -1,0 +1,62 @@
+// Copyright (c) 2002-2014 JavaMOP Team. All Rights Reserved.
+/*
+ * Copyright (C) 2007 Julio Vilmar Gesser.
+ * 
+ * This file is part of Java 1.5 parser and Abstract Syntax Tree.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Java 1.5 parser and Abstract Syntax Tree is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with Java 1.5 parser and Abstract Syntax Tree.  If not, see <http://www.gnu.org/licenses/>.
+ */
+/*
+ * Created on 05/10/2006
+ */
+package com.runtimeverification.rvmonitor.java.rvj.parser.ast.type;
+
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.GenericVisitor;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor.VoidVisitor;
+
+/**
+ * @author Julio Vilmar Gesser
+ */
+public final class WildcardType extends Type {
+
+    private final ReferenceType ext;
+
+    private final ReferenceType sup;
+
+    public WildcardType(int line, int column, ReferenceType ext, ReferenceType sup) {
+        super(line, column);
+        assert ext == null || sup == null;
+        this.ext = ext;
+        this.sup = sup;
+    }
+
+    public ReferenceType getExtends() {
+        return ext;
+    }
+
+    public ReferenceType getSuper() {
+        return sup;
+    }
+
+    @Override
+    public <A> void accept(VoidVisitor<A> v, A arg) {
+        v.visit(this, arg);
+    }
+
+    @Override
+    public <R, A> R accept(GenericVisitor<R, A> v, A arg) {
+        return v.visit(this, arg);
+    }
+
+}

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/visitor/DumpVisitor.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/visitor/DumpVisitor.java
@@ -20,6 +20,7 @@
 package com.runtimeverification.rvmonitor.java.rvj.parser.ast.visitor;
 
 import java.util.Iterator;
+import java.util.List;
 
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.ImportDeclaration;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.Node;
@@ -34,6 +35,7 @@ import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMParamete
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMParameters;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMonitorSpec;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.SpecModifierSet;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.type.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.typepattern.BaseTypePattern;
 
 /**
@@ -221,5 +223,80 @@ public class DumpVisitor implements VoidVisitor<Object> {
             printer.print(".*");
         }
         printer.printLn(";");
+    }
+
+    public void visit(ClassOrInterfaceType n, Object arg) {
+        if (n.getScope() != null) {
+            n.getScope().accept(this, arg);
+            printer.print(".");
+        }
+        printer.print(n.getName());
+        printTypeArgs(n.getTypeArgs(), arg);
+    }
+
+    protected void printTypeArgs(List<Type> args, Object arg) {
+        if (args != null) {
+            printer.print("<");
+            for (Iterator<Type> i = args.iterator(); i.hasNext();) {
+                Type t = i.next();
+                t.accept(this, arg);
+                if (i.hasNext()) {
+                    printer.print(", ");
+                }
+            }
+            printer.print(">");
+        }
+    }
+
+    public void visit(PrimitiveType n, Object arg) {
+        switch (n.getType()) {
+            case Boolean:
+                printer.print("boolean");
+                break;
+            case Byte:
+                printer.print("byte");
+                break;
+            case Char:
+                printer.print("char");
+                break;
+            case Double:
+                printer.print("double");
+                break;
+            case Float:
+                printer.print("float");
+                break;
+            case Int:
+                printer.print("int");
+                break;
+            case Long:
+                printer.print("long");
+                break;
+            case Short:
+                printer.print("short");
+                break;
+        }
+    }
+
+    public void visit(ReferenceType n, Object arg) {
+        n.getType().accept(this, arg);
+        for (int i = 0; i < n.getArrayCount(); i++) {
+            printer.print("[]");
+        }
+    }
+
+    public void visit(WildcardType n, Object arg) {
+        printer.print("?");
+        if (n.getExtends() != null) {
+            printer.print(" extends ");
+            n.getExtends().accept(this, arg);
+        }
+        if (n.getSuper() != null) {
+            printer.print(" super ");
+            n.getSuper().accept(this, arg);
+        }
+    }
+
+    public void visit(VoidType n, Object arg) {
+        printer.print("void");
     }
 }

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/visitor/GenericVisitor.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/visitor/GenericVisitor.java
@@ -33,6 +33,7 @@ import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.PropertyAnd
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMParameter;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMonitorSpec;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.typepattern.BaseTypePattern;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.type.*;
 
 /**
  * @author Julio Vilmar Gesser
@@ -70,4 +71,17 @@ public interface GenericVisitor<R, A> {
     public R visit(NameExpr n, A arg);
 
     public R visit(QualifiedNameExpr n, A arg);
+
+    // - Type ----------------------------------------------
+
+    public R visit(ClassOrInterfaceType n, A arg);
+
+    public R visit(PrimitiveType n, A arg);
+
+    public R visit(ReferenceType n, A arg);
+
+    public R visit(VoidType n, A arg);
+
+    public R visit(WildcardType n, A arg);
+
 }

--- a/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/visitor/VoidVisitor.java
+++ b/rv-monitor/src/main/java/com/runtimeverification/rvmonitor/java/rvj/parser/ast/visitor/VoidVisitor.java
@@ -30,6 +30,7 @@ import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.Formula;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.PropertyAndHandlers;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMParameter;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMonitorSpec;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.type.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.typepattern.BaseTypePattern;
 
 /**
@@ -68,4 +69,16 @@ public interface VoidVisitor<A> {
     public void visit(NameExpr n, A arg);
 
     public void visit(QualifiedNameExpr n, A arg);
+
+    //- Type ----------------------------------------------
+
+    public void visit(ClassOrInterfaceType n, A arg);
+
+    public void visit(PrimitiveType n, A arg);
+
+    public void visit(ReferenceType n, A arg);
+
+    public void visit(VoidType n, A arg);
+
+    public void visit(WildcardType n, A arg);
 }

--- a/rv-monitor/src/main/javacc/com/runtimeverification/rvmonitor/java/rvj/parser/main_parser/RVMonitorParser.jj
+++ b/rv-monitor/src/main/javacc/com/runtimeverification/rvmonitor/java/rvj/parser/main_parser/RVMonitorParser.jj
@@ -28,8 +28,10 @@ import com.runtimeverification.rvmonitor.java.rvj.parser.ast.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.expr.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.ast.typepattern.*;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.type.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.astex.*;
 import com.runtimeverification.rvmonitor.java.rvj.parser.astex.rvmspec.*;
+
 
 /**
  * Grammar to parse Java version 1.5
@@ -37,6 +39,24 @@ import com.runtimeverification.rvmonitor.java.rvj.parser.astex.rvmspec.*;
  * @author Julio Vilmar Gesser (jgesser@gmail.com) - bug fixes and added AST generation
  */
 public final class RVMonitorParser {
+        private String toTypeArgsString(List<Type> typeArgs) {
+            if(typeArgs == null) {
+                return "";
+            }
+
+            int i = 0;
+            String typeArgString = "<";
+            for(Type typeArg : typeArgs) {
+                if(i == 0) {
+                   typeArgString += typeArg.toString();
+                } else {
+                   typeArgString += ", " + typeArg.toString();
+                }
+                i += 1;
+            }
+            typeArgString += ">";
+            return typeArgString;
+        }
 }
 PARSER_END(RVMonitorParser)
 
@@ -869,37 +889,8 @@ RVMParameter RVMParameter():
 	int column;
 }
 {
-	type = SimpleTypePattern() {line = type.getBeginLine(); column = type.getBeginColumn();} (<IDENTIFIER> | "get" | "set") { name = token.image; }
+	type = TypePattern() {line = type.getBeginLine(); column = type.getBeginColumn();} (<IDENTIFIER> | "get" | "set") { name = token.image; }
 	{ return new RVMParameter(line, column, type, name); }
-}
-
-BaseTypePattern SimpleTypePattern():
-{
-	String id;
-	int line, column;
-}
-{
-	(<IDENTIFIER> | "get" | "set" ) {line = token.beginLine; column = token.beginColumn; id = token.image;}
-	("." {id += token.image;} (<IDENTIFIER> | "get" | "set") {id += token.image;})*
-	("[" {id += token.image;} "]" {id += token.image;})*
-	["+" {id += token.image;}]
-	{ return new BaseTypePattern(line, column, id); }
-}
-
-BaseTypePattern TypePattern():
-{
-	String id;
-	int line, column;
-}
-{
-	(<IDENTIFIER> | "get"| "set" | "byte" | "short" | "int"
-	| "long" | "float" | "double" | "boolean" | "char")
-	{
-		line = token.beginLine; column = token.beginColumn; id = token.image;}
-		("." {id += token.image;} (<IDENTIFIER> | "get" | "set") {id += token.image;})*
-		("[" {id += token.image;} "]" {id += token.image;})*
-		["+" {id += token.image;}]
-		{ return new BaseTypePattern(line, column, id); }
 }
 
 List<RVMParameter> AdviceParameters():
@@ -908,8 +899,8 @@ List<RVMParameter> AdviceParameters():
 	RVMParameter p = null;
 }
 {
-	"(" [ p = AdviceParameter() {parameters.add(p);} ( "," p = AdviceParameter() {parameters.add(p);} )* ] ")"
-	{ return parameters; }
+  "(" [ p = AdviceParameter() {parameters.add(p);} ( "," p = AdviceParameter() {parameters.add(p);} )* ] ")"
+  { return parameters; }
 }
 
 RVMParameter AdviceParameter():
@@ -921,9 +912,131 @@ RVMParameter AdviceParameter():
 }
 {
 	type = TypePattern() {line = type.getBeginLine(); column = type.getBeginColumn();}
-	(<IDENTIFIER> | "get" | "set") { name = token.image; }
+        (<IDENTIFIER> | "get" | "set") { name = token.image; }
 	{ return new RVMParameter(line, column, type, name); }
 }
+
+
+BaseTypePattern TypePattern():
+{
+	String id;
+	int line, column;
+	List<Type> typeArgs = null;
+}
+{
+	(<IDENTIFIER> | "get"| "set" | "byte" | "short" | "int"
+         | "long" | "float" | "double" | "boolean" | "char")
+        {
+          line = token.beginLine; column = token.beginColumn; id = token.image;}
+	[LOOKAHEAD(2) typeArgs = TypeArguments() ] { id += toTypeArgsString(typeArgs); typeArgs = null;}
+	(
+	    LOOKAHEAD(2) "." (<IDENTIFIER> | "get" | "set") {id += "." + token.image;}
+	    [ LOOKAHEAD(2) typeArgs = TypeArguments() ] {id += toTypeArgsString(typeArgs); typeArgs = null;}
+	)*
+	("[" {id += token.image;} "]" {id += token.image;})*
+	["+" {id += token.image;}]
+	{ return new BaseTypePattern(line, column, id); }
+}
+
+List TypeArguments():
+{
+	List ret = new LinkedList();
+	Type type;
+}
+{
+   "<" type = TypeArgument() { ret.add(type); } ( "," type = TypeArgument() { ret.add(type); } )* ">"
+   { return ret; }
+}
+
+Type TypeArgument():
+{
+	Type ret;
+}
+{
+ (
+   ret = ReferenceType()
+ |
+   ret = Wildcard()
+ )
+ { return ret; }
+}
+
+WildcardType Wildcard():
+{
+	ReferenceType ext = null;
+	ReferenceType sup = null;
+	int line;
+	int column;
+}
+{
+   "?" {line=token.beginLine; column=token.beginColumn;}
+   [
+		"extends" ext = ReferenceType()
+	|
+		"super" sup = ReferenceType()
+   ]
+   { return new WildcardType(line, column, ext, sup); }
+}
+
+ReferenceType ReferenceType():
+{
+	Type type;
+	int arrayCount = 0;
+}
+{
+  (
+   type = PrimitiveType() ( LOOKAHEAD(2) "[" "]" { arrayCount++; } )+
+  |
+   type = ClassOrInterfaceType() ( LOOKAHEAD(2) "[" "]" { arrayCount++; } )*
+  )
+  { return new ReferenceType(type.getBeginLine(), type.getBeginColumn(), type, arrayCount); }
+}
+
+PrimitiveType PrimitiveType():
+{
+	PrimitiveType ret;
+}
+{
+(
+  "boolean" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Boolean); }
+|
+  "char" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Char); }
+|
+  "byte" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Byte); }
+|
+  "short" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Short); }
+|
+  "int" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Int); }
+|
+  "long" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Long); }
+|
+  "float" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Float); }
+|
+  "double" { ret = new PrimitiveType(token.beginLine, token.beginColumn, PrimitiveType.Primitive.Double); }
+)
+{ return ret; }
+}
+
+ClassOrInterfaceType ClassOrInterfaceType():
+{
+	ClassOrInterfaceType ret;
+	String name;
+	List typeArgs = null;
+	int line;
+	int column;
+}
+{
+  (<IDENTIFIER> | "get" | "set")  {line=token.beginLine; column=token.beginColumn;} { name = token.image; }
+  [ LOOKAHEAD(2) typeArgs = TypeArguments() ]
+  { ret = new ClassOrInterfaceType(line, column, null, name, typeArgs); }
+  (
+	  LOOKAHEAD(2) "." (<IDENTIFIER> | "get" | "set") { name = token.image; }
+	  [ LOOKAHEAD(2) typeArgs = TypeArguments() ] { ret = new ClassOrInterfaceType(line, column, ret, name, typeArgs); }
+  )*
+  { return ret; }
+}
+
+
 
 /***********************************************
  * THE JAVARVM SPECIFICATION GRAMMAR ENDS HERE *
@@ -974,3 +1087,5 @@ NameExpr Name():
 	( LOOKAHEAD(2) "." (<IDENTIFIER> | "get" | "set") { ret = new QualifiedNameExpr(token.beginLine, token.beginColumn, ret, token.image); } )*
 	{ return ret; }
 }
+
+

--- a/rv-monitor/src/test/java/com/runtimeverification/rvmonitor/examples/java/JavaSpecificSyntaxTests.java
+++ b/rv-monitor/src/test/java/com/runtimeverification/rvmonitor/examples/java/JavaSpecificSyntaxTests.java
@@ -1,0 +1,4 @@
+package com.runtimeverification.rvmonitor.examples.java;
+
+public class JavaSpecificSyntaxTests {
+}

--- a/rv-monitor/src/test/java/com/runtimeverification/rvmonitor/examples/java/JavaSpecificSyntaxTests.java
+++ b/rv-monitor/src/test/java/com/runtimeverification/rvmonitor/examples/java/JavaSpecificSyntaxTests.java
@@ -1,4 +1,88 @@
 package com.runtimeverification.rvmonitor.examples.java;
 
+import com.runtimeverification.rvmonitor.java.rvj.JavaParserAdapter;
+import com.runtimeverification.rvmonitor.java.rvj.parser.ast.rvmspec.RVMParameters;
+import com.runtimeverification.rvmonitor.java.rvj.parser.astex.RVMSpecFileExt;
+import com.runtimeverification.rvmonitor.java.rvj.parser.astex.rvmspec.EventDefinitionExt;
+import com.runtimeverification.rvmonitor.java.rvj.parser.astex.rvmspec.RVMonitorSpecExt;
+import com.runtimeverification.rvmonitor.util.RVMException;
+import org.junit.Test;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+
 public class JavaSpecificSyntaxTests {
+
+    private static final String errIncorrectArgNum = "Unexpected number of parameters";
+    private static final String errIncorrectGenericType = "Unexpected number of parameters";
+
+    private File fromResources(Path filePath) {
+        ClassLoader classLoader = getClass().getClassLoader();
+
+        return new File(classLoader.getResource(filePath.toString()).getFile());
+    }
+
+    private EventDefinitionExt getEvent(String folder, String name) {
+        RVMSpecFileExt parsedFile = null;
+        try {
+            parsedFile = JavaParserAdapter.parse(fromResources(Paths.get(folder, name)));
+            assertNotNull("Parser neither parsed file nor threw exception", parsedFile);
+
+        } catch (RVMException e) {
+            fail("Unexpected ParseException" + e.getMessage());
+        }
+
+        List<RVMonitorSpecExt> specs = parsedFile.getSpecs();
+        assertEquals("Unexpected number of Spec ASTs", 1, specs.size());
+        RVMonitorSpecExt spec = specs.get(0);
+
+        List<EventDefinitionExt> events = spec.getEvents();
+        assertEquals("Unexpected number of Event ASTs", 1, events.size());
+
+        return events.get(0);
+    }
+
+    @Test
+    public void testGenericsInAdviceParams() {
+        EventDefinitionExt testEvent = getEvent("java", "AdviceParamsWithGenerics.rvm");
+        RVMParameters adviceParams = testEvent.getParameters();
+
+        assertEquals(errIncorrectArgNum, 1, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                , "List<Bar>"
+                , adviceParams.get(0).getType().toString());
+    }
+
+    @Test
+    public void testGenericsInAdviceParamsMultiple() {
+        EventDefinitionExt testEvent = getEvent("java", "AdviceParamsWithGenericsMultiple.rvm");
+        RVMParameters adviceParams = testEvent.getParameters();
+
+        assertEquals(errIncorrectArgNum, 2, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                , "List<Bar>"
+                , adviceParams.get(0).getType().toString());
+
+        assertEquals(errIncorrectGenericType
+                , "List<Foo>"
+                , adviceParams.get(1).getType().toString());
+    }
+
+
+    @Test
+    public void testGenericsInAdviceParamsNested() {
+        EventDefinitionExt testEvent = getEvent("java", "AdviceParamsWithGenericsNested.rvm");
+        RVMParameters adviceParams = testEvent.getParameters();
+
+        assertEquals(errIncorrectArgNum, 1, adviceParams.size());
+        assertEquals(errIncorrectGenericType
+                , "List<List<Bar>>"
+                , adviceParams.get(0).getType().toString());
+
+    }
 }

--- a/rv-monitor/src/test/resources/java/AdviceParamsWithGenerics.rvm
+++ b/rv-monitor/src/test/resources/java/AdviceParamsWithGenerics.rvm
@@ -1,0 +1,16 @@
+package rvm;
+
+import java.io.*;
+import java.util.*;
+
+HasNext () {
+
+    event foo (List<Bar> buzz) {}
+
+    ere : (foo)*
+
+    @fail {
+      System.out.println("Test handler");
+    }
+}
+

--- a/rv-monitor/src/test/resources/java/AdviceParamsWithGenericsMultiple.rvm
+++ b/rv-monitor/src/test/resources/java/AdviceParamsWithGenericsMultiple.rvm
@@ -1,0 +1,16 @@
+package rvm;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsMultiple () {
+
+    event foo (List<Bar> buzz, List<Foo> fuzz) {}
+
+    ere : (foo)*
+
+    @fail {
+      System.out.println("Multiple Generics");
+    }
+}
+

--- a/rv-monitor/src/test/resources/java/AdviceParamsWithGenericsNested.rvm
+++ b/rv-monitor/src/test/resources/java/AdviceParamsWithGenericsNested.rvm
@@ -1,0 +1,15 @@
+package rvm;
+
+import java.io.*;
+import java.util.*;
+
+AdviceParamsWithGenericsNested () {
+
+    event foo (List<List<Bar>> buzz) {}
+
+    ere : (foo)*
+
+    @fail {
+      System.out.println("Nested Generics");
+    }
+}


### PR DESCRIPTION
Generics like `List<Foo>` will now parse