### PR TITLE
make regex more precise to capture event declaration.

### DIFF
--- a/rv-monitor/src/main/javacc/com/runtimeverification/rvmonitor/core/parser/RVParser.jj
+++ b/rv-monitor/src/main/javacc/com/runtimeverification/rvmonitor/core/parser/RVParser.jj
@@ -251,7 +251,7 @@ Specification specification() : {
     (languageParameters = delimitedNoCurly())?
     "{"
         {languageDeclarations = parseUntilLineMatches(Pattern.compile(
-            "^([-a-zA-Z\\s_]*)event([a-zA-Z_\\s0-9]+)\\("));}
+            "^([-a-zA-Z\\s_]*)\bevent\b([a-zA-Z_\\s0-9]+)\\(.*\\)(\\s)*\\{"));}
         (LOOKAHEAD( 2 ) myEvent = event() { events.add(myEvent); })+
         (myProperty = propertyAndHandlers() {properties.add(myProperty);})*
     "}"


### PR DESCRIPTION
The original regular expression will regard the following java function
`public void eventA(...) { }` as the event declaration. We update the regular expression to exclude this case.