### PR TITLE
escape \b in the regexp and pass all the integration tests

### DIFF
--- a/rv-monitor/src/main/javacc/com/runtimeverification/rvmonitor/core/parser/RVParser.jj
+++ b/rv-monitor/src/main/javacc/com/runtimeverification/rvmonitor/core/parser/RVParser.jj
@@ -251,7 +251,7 @@ Specification specification() : {
     (languageParameters = delimitedNoCurly())?
     "{"
         {languageDeclarations = parseUntilLineMatches(Pattern.compile(
-            "^([-a-zA-Z\\s_]*)\bevent\b([a-zA-Z_\\s0-9]+)\\(.*\\)(\\s)*\\{"));}
+            "^([-a-zA-Z\\s_]*)\\bevent\\b([a-zA-Z_\\s0-9]+)\\("));}
         (LOOKAHEAD( 2 ) myEvent = event() { events.add(myEvent); })+
         (myProperty = propertyAndHandlers() {properties.add(myProperty);})*
     "}"


### PR DESCRIPTION
previous fix has 2 issues:
1. we need to escape \b in the regex
2. "{" can appear on the second line.

Now all the tests passed with `mvn clean verify`. Note that `mvn clean test` will not run the (integration) tests for the rv-monitor.